### PR TITLE
add new variable to the grid also fills the label field with the same name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BlueSky
 Type: Package
 Title: BlueSky Collection of Functions for Data Access, Analysis, and Formatting.
-Version: 9.0
-Date: 2024-10-18
+Version: 9.1
+Date: 2024-11-07
 Depends: R (>= 4.0.0)
 Author: BlueSky Statistics.
 Maintainer: contact us <support@blueskystatistics.com>

--- a/R/BSkyVersion.r
+++ b/R/BSkyVersion.r
@@ -14,9 +14,9 @@
 #' @examples BSkyVersion()
 BSkyVersion<-function(fulldetails=TRUE)
 {
-	bskyver= "Version: 9.0"
-	bskydate="Date: 2024-10-18"
-	bskytime="07:15PM"
+	bskyver= "Version: 9.1"
+	bskydate="Date: 2024-11-07"
+	bskytime="06:15PM"
 
 	if(fulldetails)
 	{

--- a/R/GridOperations.R
+++ b/R/GridOperations.R
@@ -1245,30 +1245,30 @@ BSkyAddVarRow <-function (newcolname, rdatatype, datagridcolval, newcolindex = 0
                 "Columns", "Role","DateFormat")
 				#Added by Aaron 06/25/2020 passed string below
             if (rdatatype == "character") {
-                pval <- list(newcolname, rdatatype, newcolname,
+                pval <- list(newcolname, rdatatype, "",
                   NULL, "none", "Left", "String", FALSE, 4, 0,
                   8, "Input", "")
             }
             else if (rdatatype == "double") {
-                pval <- list(newcolname, rdatatype, newcolname,
+                pval <- list(newcolname, rdatatype, "",
                   NULL, "none", "Left", "Scale", FALSE, 4, 0, 8,
                   "Input", "")
             }
 			 else if (rdatatype == "POSIXct") {
-                pval <- list(newcolname, rdatatype, newcolname,
+                pval <- list(newcolname, rdatatype, "",
                   NULL, "none", "Left", "Date", FALSE, 4, 0, 8,
                   "Input", DateFormat)
             }
 			else if (rdatatype == "factor")
 			{
-			pval <- list(newcolname, rdatatype, newcolname,
+			pval <- list(newcolname, rdatatype, "",
 							  "", "none", "Left", "Nominal", FALSE, 4, 0, 8,
 							  "Input", "")
 			}
 			#Added by Aaron 06/25/2020 passed Ordinal below
 			else if (rdatatype == "ordered")
 			{
-			pval <- list(newcolname, rdatatype, newcolname,
+			pval <- list(newcolname, rdatatype, "",
 							  "", "none", "Left", "Ordinal", FALSE, 4, 0, 8,
 							  "Input", "")
 			}


### PR DESCRIPTION
…  as the variable name created (e.g. newvariable1). We want "label" to be blank. This fix has been made in this commit.