### PR TITLE
Resolve rcorr.adjust via the RcmdrMisc namespace in the correlation functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Author: BlueSky Statistics.
 Maintainer: contact us <support@blueskystatistics.com>
 Description: This package provides a variety of useful functions for accessing data, analyzing data and creating publication-quality output in text, HTML, and LaTeX. The functions are used extensively in the BlueSky Statistics user interface to R, but are useful to any R users.
 Imports: gdata, stringr, openxlsx, haven, readr, readxl, data.table, foreign, kableExtra, tidyverse, formatR, dplyr, effectsize, RcmdrMisc, DescTools
+Suggests: testthat (>= 3.0.0)
 License: GPL (version 2 or later)
 LazyLoad: yes
 RoxygenNote: 7.1.2

--- a/R/BSkyCorrelation.R
+++ b/R/BSkyCorrelation.R
@@ -65,7 +65,7 @@ BSkyCorrelationMatrix <-function  (data, vars=NULL, correlationType = "Pearson",
 		vars = dimnames(data)[[2]]
 	}
 	
-	BSky_Correlation_Matrix_Type = rcorr.adjust(data[,vars], use=missingValues, type = tolower(correlationType))
+	BSky_Correlation_Matrix_Type = RcmdrMisc::rcorr.adjust(data[,vars], use=missingValues, type = tolower(correlationType))
 	showPvalue = pValue
 	results <- BSkyFormatRcorr_adjust(BSky_Correlation_Matrix_Type, showPvalue)
 	row.names(results) <- NULL
@@ -129,7 +129,7 @@ BSkyPlotCorrelationMatrix <-function  (data, vars=NULL, correlationType = "Pears
 		vars = dimnames(data)[[2]]
 	}
 	
-		BSky_Correlation_Matrix_Type = rcorr.adjust(data[,vars], use=missingValues, type = tolower(correlationType))
+		BSky_Correlation_Matrix_Type = RcmdrMisc::rcorr.adjust(data[,vars], use=missingValues, type = tolower(correlationType))
 		#m = base::round(BSky_Correlation_Matrix_Type[[1]]$r, digits =BSkyGetDecimalDigitSetting())
 		m = BSky_Correlation_Matrix_Type[[1]]$r
 		

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(BlueSky)
+
+test_check("BlueSky")

--- a/tests/testthat/test-BSkyCorrelation.R
+++ b/tests/testthat/test-BSkyCorrelation.R
@@ -1,0 +1,20 @@
+test_that("BSkyCorrelationMatrix resolves rcorr.adjust without RcmdrMisc attached", {
+  skip_if_not_installed("RcmdrMisc")
+
+  # BlueSky never attaches RcmdrMisc, so the correlation code must reach
+  # rcorr.adjust() through RcmdrMisc:: rather than by bare name; recreate a
+  # session with RcmdrMisc off the search path and confirm the call resolves.
+  was_attached <- "package:RcmdrMisc" %in% search()
+  if (was_attached) detach("package:RcmdrMisc", character.only = TRUE, unload = FALSE)
+  on.exit(if (was_attached) suppressPackageStartupMessages(library(RcmdrMisc)), add = TRUE)
+
+  err <- tryCatch({
+    BSkyCorrelationMatrix(mtcars, vars = c("mpg", "hp", "disp"))
+    NULL
+  }, error = function(e) conditionMessage(e))
+
+  expect_false(
+    !is.null(err) && grepl("could not find function .rcorr.adjust.", err),
+    info = err
+  )
+})


### PR DESCRIPTION
This PR proposes qualifying the two `rcorr.adjust()` calls in the correlation functions with `RcmdrMisc::` so `BSkyCorrelationMatrix()` and `BSkyPlotCorrelationMatrix()` resolve that function in a plain `library(BlueSky)` session. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/303. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`BSkyCorrelationMatrix()` and `BSkyPlotCorrelationMatrix()` in `R/BSkyCorrelation.R` call `rcorr.adjust()` (from RcmdrMisc) by bare name. RcmdrMisc is listed under `Imports:` in `DESCRIPTION`, but it is neither imported in `NAMESPACE` nor attached in `.onLoad`, so that bare name is unresolvable in any session where RcmdrMisc is not already on the search path — which is exactly the state after a plain `library(BlueSky)`. Running a correlation then fails with `could not find function "rcorr.adjust"`, the error reported in issue #8.

Reproduced on a clean checkout of `main` (RcmdrMisc installed but not attached, mirroring the package's own namespace):

```
> source("R/BSkyCorrelation.R")
> BSkyCorrelationMatrix(mtcars, vars = c("mpg", "hp", "disp"))
Error in BSkyCorrelationMatrix(mtcars, vars = c("mpg", "hp", "disp")) :
  could not find function "rcorr.adjust"
```

## The change

Both call sites now read `RcmdrMisc::rcorr.adjust(...)`, mirroring the `DescTools::PlotCorr()` and `DescTools::PlotWeb()` calls already used a few lines below in `BSkyPlotCorrelationMatrix()`. There is no change to any signature, default, or returned value — the function is reached through its declared namespace instead of by bare name. I verified the behavior with RcmdrMisc both off and on the search path, before and after the change; the previously-working attached path returns the identical table:

```
                     bare rcorr.adjust (before)   RcmdrMisc:: (after)
RcmdrMisc detached   could not find function       9-row table   (now works)
RcmdrMisc attached   9-row table                   9-row table   (unchanged)
```

A regression test under `tests/testthat/` runs `BSkyCorrelationMatrix(mtcars, ...)` with RcmdrMisc off the search path: it fails on `main` with `could not find function "rcorr.adjust"` and passes with this change. `testthat` is added to `Suggests` so the test can run; nothing in the shipped package's dependencies changes. Fixes #8.

## How this was managed

We imported your open issues and pull requests into a live board (34 stories) and used it to track this work; this fix maps to the story [Correlation problem, code only](https://eastagiletracker.com/projects/303/stories/197209) on the board at https://eastagiletracker.com/projects/303.

![board](https://raw.githubusercontent.com/eastagiletracker/BlueSky/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
